### PR TITLE
fix tcp header format.

### DIFF
--- a/Data/TCP.hs
+++ b/Data/TCP.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, FlexibleInstances, DeriveDataTypeable #-}
 module Data.TCP
-	( TCPPort
+	( TCPPort (..)
 	, TCPHeader (..)
 	) where
 
@@ -56,8 +56,8 @@ instance Serialize TCPHeader where
 		put seq
 		put ack
 		let datRes = ((dat .&. 0xF) `shiftL` 4) .|. (res .&. 0xF)
-		put datRes
-		put (fromEnum fs)
+		putWord8 (fromIntegral datRes)
+		putWord8 (fromIntegral $ fromEnum fs)
 		putWord16be (fromIntegral w .&. 0xFFFF)
 		put c
 		putWord16be (fromIntegral u .&. 0xFFFF)
@@ -66,10 +66,10 @@ instance Serialize TCPHeader where
 		d <- get
 		seq <- get
 		ack <- get
-		datRes <- get
+		datRes <- fmap fromIntegral getWord8
 		let dat = (datRes `shiftR` 4) .&. 0xF
 		    res = datRes .&. 0xF
-		fs <- get >>= return . toEnum
+		fs <- fmap (toEnum . fromIntegral) getWord8
 		w <- getWord16be >>= return . fromIntegral
 		c <- get
 		u <- getWord16be >>= return . fromIntegral


### PR DESCRIPTION
By the way, note that HaNS package has more full-featured protocol parsers [1]. But HaNS is too big a package to dependent on in many cases, in contrast network-data is a much more lightweight option. 
I think we can borrow some codes from them?

[1]. https://github.com/GaloisInc/HaNS/tree/master/src/Hans/Message
