### PR TITLE
Location of github repo & 802.1Q VLAN tags

### DIFF
--- a/network-data.cabal
+++ b/network-data.cabal
@@ -1,5 +1,5 @@
 name:           network-data
-version:        0.4
+version:        0.5
 license:        BSD3
 license-file:   LICENSE
 author:         Thomas DuBuisson <thomas.dubuisson@gmail.com>


### PR DESCRIPTION
I've added the location of the github repo in the cabal file & bumped the version to 0.5. I also added support in the Ethernet header for 802.1Q VLAN tagging (http://en.wikipedia.org/wiki/IEEE_802.1Q)
