### PR TITLE
fixed wrong order of fragmentation bit flags in fragmentOffset field of IPv4 header

### DIFF
--- a/Data/IP.hs
+++ b/Data/IP.hs
@@ -47,9 +47,9 @@ instance Enum [IPv4Flag] where
         fromEnum xs = foldl' (.|.) 0 $ map fromEnum1 xs
         toEnum f = map snd $ filter fst [(testBit f 0, Res), (testBit f 1, MF), (testBit f 2, DF)]
 
-fromEnum1 DF   = 4
-fromEnum1 MF   = 2
-fromEnum1 Res  = 1
+fromEnum1 MF   = 1
+fromEnum1 DF   = 2
+fromEnum1 Res  = 4
 
 -- |This IPv4 header structure lacks support for options.  Ints are used
 -- for most integral data types and the binary instance hands the bit packing.

--- a/network-data.cabal
+++ b/network-data.cabal
@@ -1,5 +1,5 @@
 name:           network-data
-version:        0.5
+version:        0.5.1
 license:        BSD3
 license-file:   LICENSE
 author:         Thomas DuBuisson <thomas.dubuisson@gmail.com>


### PR DESCRIPTION
Hi Tom! Looks like there was an error in serializing the flags field:
according to RFC791

  Flags:  3 bits

```
Various Control Flags.

  Bit 0: reserved, must be zero
  Bit 1: (DF) 0 = May Fragment,  1 = Don't Fragment.
  Bit 2: (MF) 0 = Last Fragment, 1 = More Fragments.

      0   1   2
    +---+---+---+
    |   | D | M |
    | 0 | F | F |
    +---+---+---+
```

These are highest bits of fragmentOffset field, so if you're moving all the triplet 13 bits left, MF should be 1, DF - 2 and Res - 4.

Hope I did it right.
Thanks for such a helpful package, BTW! It's great for testing my C networking code with QuickCheck ;)
