### PR TITLE
Removed prettyclass dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+cabal.sandbox.config
+.cabal-sandbox
+dist/
+*.sw[a-z]

--- a/Data/Ethernet.hs
+++ b/Data/Ethernet.hs
@@ -71,7 +71,7 @@ instance Serialize EthernetHeader where
 instance Pretty Ethernet where
     pPrint (Ethernet o0 o1 o2 o3 o4 o5)
         = text
-        . concat 
-        . intersperse "::" 
-        . map (flip showHex "") 
+        . concat
+        . intersperse "::"
+        . map (flip showHex "")
         $ [o0, o1, o2, o3, o4, o5]

--- a/network-data.cabal
+++ b/network-data.cabal
@@ -20,13 +20,12 @@ Flag small_base
 
 Library
   Build-Depends: base >= 3 && < 5,
-                   bytestring >= 0.9,
-                   cereal >= 0.2,
-                   prettyclass >= 1.0,
-                   pretty >= 1.0
+                 bytestring >= 0.9,
+                 cereal >= 0.2,
+                 pretty >= 1.0
   hs-source-dirs:
   exposed-modules: Data.Ethernet, Data.IP, Data.IPv6, Data.Header, Data.TCP, Data.UDP, Data.CSum
-  ghc-options: 
+  ghc-options:
 
 source-repository head
   type:     git


### PR DESCRIPTION
I was getting the error:
```bash
Data/Ethernet.hs:24:8:
    Ambiguous module name ‘Text.PrettyPrint.HughesPJClass’:
      it was found in multiple packages:
      pretty-1.1.2.0@prett_7jIfj8VCGFf1WS0tIQ1XSZ prettyclass-1.0.0.0@prett_FSrzsDJUOMuAZvmMJwseSZ
```

And realized that Text.PrettyPrint.HughesPJClass was duplicated in pretty.